### PR TITLE
Css/homepage

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -7,6 +7,7 @@ const Header = () => {
   <NavLink to="/">
       <h1>Rancid Tomatillos</h1>
   </NavLink>
+  {/* <NavLink to="/favorites" /> */}
     </header>
   )
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { NavLink } from "react-router-dom"
+
+const Header = () => {
+  return (
+    <header>
+  <NavLink to="/">
+      <h1>Rancid Tomatillos</h1>
+  </NavLink>
+    </header>
+  )
+}
+
+export default Header;

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,0 +1,8 @@
+header {
+  border-bottom: $border-underline;
+  &::after {
+    content: "";
+    border-bottom: 10px solid $color-secondary  ;
+    width: 100vw;
+  }
+}

--- a/src/components/MovieBoard/MovieBoard.scss
+++ b/src/components/MovieBoard/MovieBoard.scss
@@ -2,7 +2,7 @@
     display: grid;
     justify-items: center;
     grid-template-columns: repeat(2, 1fr);
-    gap: 2rem 0;
+    gap: 1.2rem 0;
     padding: 1rem 0;
     transition: 500ms;
     :hover{

--- a/src/components/MovieBoard/MovieBoard.scss
+++ b/src/components/MovieBoard/MovieBoard.scss
@@ -1,13 +1,13 @@
 .movies-container {
-    display: grid;
-    justify-items: center;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1.2rem 0;
-    padding: 1rem 0;
-    transition: 500ms;
+    @include mobile;
+    @include tablet;
+    @include desktop;
+    margin-top: 1rem;
+    transition: ease-in-out all 500ms;
     :hover{
         transition: 500ms;
         opacity: 1;
     }
+
 }
 

--- a/src/components/MovieBoard/MovieBoard.scss
+++ b/src/components/MovieBoard/MovieBoard.scss
@@ -2,5 +2,12 @@
     display: grid;
     justify-items: center;
     grid-template-columns: repeat(2, 1fr);
-    gap: .8rem;
+    gap: 2rem 0;
+    padding: 1rem 0;
+    transition: 500ms;
+    :hover{
+        transition: 500ms;
+        opacity: 1;
+    }
 }
+

--- a/src/components/MovieCover/MovieCover.scss
+++ b/src/components/MovieCover/MovieCover.scss
@@ -1,17 +1,21 @@
 .movie-card {
     position: relative;
-    opacity: .75;
-    width: 10rem;
-    height: 13rem;
+    width: clamp(10rem, 5vw, 15rem);
+    height: clamp(15rem, 5vh, 20rem);
     transition: 500ms;
-  
+    transform: translateY(10px);
     img {
         position: absolute;
         border-radius: $borders-curve;
         box-shadow: 0 0 10px  $color-dark;
         width: 100%;
         height: 100%;
+        transition: 500ms;
+        &:hover {
+            filter: brightness(1.1);
+            transition: 300ms;
+            transform: translateY(-5px) scale3d(1, 1 ,1);
+        }
     }
-  
 }
 

--- a/src/components/MovieCover/MovieCover.scss
+++ b/src/components/MovieCover/MovieCover.scss
@@ -1,12 +1,17 @@
 .movie-card {
     position: relative;
-    border: 1px solid black;
-    width: 10rem;
-    height: 13rem;
+    opacity: .75;
+    width: 17rem;
+    height: 20rem;
+    transition: 500ms;
+  
     img {
+        position: absolute;
+        border-radius: $borders-curve;
+        box-shadow: 0 0 10px  $color-dark;
         width: 100%;
         height: 100%;
-        position: absolute;
     }
+  
 }
 

--- a/src/components/MovieCover/MovieCover.scss
+++ b/src/components/MovieCover/MovieCover.scss
@@ -1,8 +1,8 @@
 .movie-card {
     position: relative;
     opacity: .75;
-    width: 17rem;
-    height: 20rem;
+    width: 10rem;
+    height: 13rem;
     transition: 500ms;
   
     img {

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -1,6 +1,7 @@
 import MovieBoard from '../MovieBoard/MovieBoard';
 import Movie from '../Movie/Movie';
 import Error from '../Error/Error';
+import Header from '../Header/Header'
 import React, { Component } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { cleanMovies, cleanMovie } from '../../utils';
@@ -64,9 +65,7 @@ class App extends Component {
   render() {
     return (
       <main> 
-        <header className='app-title'>
-          <h1>Rancid Tomatillos</h1>
-        </header>
+      <Header />
         <Switch>
           <Route exact path='/' render={() => {
               return (

--- a/src/styles/elements/_elements.scss
+++ b/src/styles/elements/_elements.scss
@@ -6,13 +6,17 @@ body {
   color: $color-light;
 }
 
-header {
-  background: $color-tertierary;
-  text-align: center;
+
+main, header {
+  @include flex(column, center);
 }
 
-h1{
-@include heading;
+a  {
+  color: $color-secondary;
+}
+
+h1 {
+  @include heading;
 }
 
 h2 {
@@ -20,10 +24,11 @@ h2 {
 }
 
 h3 {
-@include paragraph;
+  @include paragraph;
   font-weight: bolder;
 }
 
 h4, p {
   @include paragraph;
 }
+

--- a/src/styles/settings/_borders.scss
+++ b/src/styles/settings/_borders.scss
@@ -3,3 +3,4 @@ Settings - Borders
 ========================================================================== */
 
 $borders-curve: 3px;
+$border-underline: 4px solid $color-light;

--- a/src/styles/settings/_typography.scss
+++ b/src/styles/settings/_typography.scss
@@ -18,7 +18,7 @@ $font-style-defaults: normal;
 $font-family-primary: 'Teko', sans-serif;
 
 /* === Font Size === */
-$font-size-heading: 2.5rem, 6vw,  7rem;
+$font-size-heading: 3rem, 6vw,  7rem;
 $font-size-subheading: 1.5rem,  4vw,  6rem;
 $font-size-paragraph: 1rem, 4vw, 2.5rem;
 $font-size-button: 1rem, 3vw, 2rem;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -3,8 +3,8 @@
 Settings - Global Variables
 ========================================================================== */
 
-@import './settings/borders';
 @import './settings/colors';
+@import './settings/borders';
 @import './settings/typography';
 
 /* ==========================================================================
@@ -37,6 +37,7 @@ Objects - Undecorated Design Patterns (Component Generics)
 
 @import '../components/App/App.scss';
 @import '../components/Error/Error.scss';
+@import '../components/Header/Header.scss';
 @import '../components/Movie/Movie.scss';
 @import '../components/MovieBoard/MovieBoard.scss';
 @import '../components/MovieCover/MovieCover.scss';

--- a/src/styles/tools/_mixins.scss
+++ b/src/styles/tools/_mixins.scss
@@ -25,6 +25,21 @@ Tools - Mixins
   }
 }
 
+/* === Grid === */
+@mixin grid($viewport) {
+  display: grid;
+  justify-items: center;
+  @if $viewport == mobile {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem 1rem;
+  } @else if $viewport == tablet {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 2rem 2rem;
+  } @else {
+    grid-template-columns: repeat(5, 1fr);
+    gap: 4rem 4rem;
+  }
+}
 
 /* === Fonts === */
 @mixin scaling-font($element) {
@@ -55,16 +70,24 @@ Tools - Mixins
 }
  
 /* === Media Queries === */
-@mixin phone {
-  @media only screen and (max-width: 375px) {
+@mixin mobile {
+  @media only screen and (min-width: 375px) {
     @content;
-    font-size: calc(20px + (32 + 20) * ((100vw - 375px) / (1000 - 375)));
+  
+    @include grid(mobile)
   }
 }
 
 @mixin tablet {
-  @media only screen and (min-width: 1000px) {
+  @media only screen and (min-width: 768px) {
     @content;
-    font-size: 32px;
+    @include grid(tablet)
+  }
+}
+
+@mixin desktop {
+  @media only screen and (min-width: 1100px) {
+    @content;
+    @include grid(desktop)
   }
 }


### PR DESCRIPTION
This PR cleans up the homepage and add media queries to movie posters. 

## Description
Although the homepage isn't  _glamerous,_ it does work really well functionally. I added media queries and clamp/transitions to the break points (mobile, tablet, desktop), which gives a sort of a grow/bounce effect. Other some changes include separating header into its own component.


## Motivation and Context
The homepage needed some TLC and it wasn't responsive. I wanted to incorporate the same fluid growth to the movie posters using `clamp()`  and added media query mixins with grid. Header was made into its own component because now it'll hoist a home link(header) and a favorites 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Refactor

## Checklist:
- Add hover elements 
- Adjust media queries mixins to contain grid
- Add grid mixins
- Add header component 

## Screenshot:

![movie](https://user-images.githubusercontent.com/17935770/125979020-34504f6e-a880-44c3-a53b-564b8a790d77.gif)

