### PR TITLE
Iteration 5/favorites page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
+        "@fortawesome/free-regular-svg-icons": "^5.15.3",
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "@fortawesome/react-fontawesome": "^0.1.14",
         "@testing-library/jest-dom": "^5.14.1",
@@ -1953,6 +1954,18 @@
       "version": "1.2.35",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
       "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-q4/p8Xehy9qiVTdDWHL4Z+o5PCLRChePGZRTXkl+/Z7erDVL8VcZUuqzJjs6gUz6czss4VIPBRdCz6wP37/zMQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.35"
@@ -25060,6 +25073,14 @@
       "version": "1.2.35",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
       "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-q4/p8Xehy9qiVTdDWHL4Z+o5PCLRChePGZRTXkl+/Z7erDVL8VcZUuqzJjs6gUz6czss4VIPBRdCz6wP37/zMQ==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.35"
       }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
+    "@fortawesome/free-regular-svg-icons": "^5.15.3",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -10,13 +10,14 @@ const Header = () => {
     <header>
 
   <NavLink to="/">
-  <FontAwesomeIcon icon={faBackward} />
+  <FontAwesomeIcon className="icon" icon={faBackward} />
   </NavLink>
+
   <NavLink to="/">
   <h1>Rancid Tomatillos</h1>
   </NavLink>
   <NavLink to="/favorites">
-  <FontAwesomeIcon icon={faHeart} />
+  <FontAwesomeIcon className="icon" icon={faHeart} />
   </NavLink>
     </header>
   )

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,11 +1,22 @@
 import React from "react";
 import { NavLink } from "react-router-dom"
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faHeart } from '@fortawesome/free-regular-svg-icons'
+import { faBackward } from '@fortawesome/free-solid-svg-icons'
+
 
 const Header = () => {
   return (
     <header>
+
   <NavLink to="/">
-      <h1>Rancid Tomatillos</h1>
+  <FontAwesomeIcon icon={faBackward} />
+  </NavLink>
+  <NavLink to="/">
+  <h1>Rancid Tomatillos</h1>
+  </NavLink>
+  <NavLink to="/favorites">
+  <FontAwesomeIcon icon={faHeart} />
   </NavLink>
   {/* <NavLink to="/favorites" /> */}
     </header>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -5,22 +5,29 @@ import { faHeart } from '@fortawesome/free-regular-svg-icons'
 import { faBackward } from '@fortawesome/free-solid-svg-icons'
 
 
-const Header = () => {
+const Header = ({path}) => {
+console.log(path)
+
   return (
     <header>
 
+{ !!path === "/" && 
   <NavLink to="/">
   <FontAwesomeIcon className="icon" icon={faBackward} />
-  </NavLink>
+  </NavLink> }
 
   <NavLink to="/">
   <h1>Rancid Tomatillos</h1>
   </NavLink>
-  <NavLink to="/favorites">
+
+{ path !== "/favorites"  && <NavLink to="/favorites">
   <FontAwesomeIcon className="icon" icon={faHeart} />
-  </NavLink>
+  </NavLink> }
+
+    {/* {console.log(path === "/favorites")} */}
+
     </header>
-  )
+  ) 
 }
 
 export default Header;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -18,7 +18,6 @@ const Header = () => {
   <NavLink to="/favorites">
   <FontAwesomeIcon icon={faHeart} />
   </NavLink>
-  {/* <NavLink to="/favorites" /> */}
     </header>
   )
 }

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,12 +1,10 @@
 header {
+  @include flex(row, space);
   @include opacity ($color-dark, -0.5);
   border-bottom: $border-underline;
-  &::after {
-    content: "";
-    border-bottom: 1rem solid $color-light;
-    width: 100vw;
-  }
+  width: 100%;
   h1 {
     align-self: center;
   }
+
 }

--- a/src/components/Movie/Movie.js
+++ b/src/components/Movie/Movie.js
@@ -1,6 +1,5 @@
 import React, {Component} from 'react';
 import {Link} from 'react-router-dom';
-// import { sortGenres } from '../../utils'
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHeart } from '@fortawesome/free-solid-svg-icons'
@@ -104,7 +103,3 @@ Movie.propTypes = {
     runtime: PropTypes.number,
     tagline: PropTypes.string
 }
-
-
-{/* <FontAwesomeIcon className={this.props.movieInfo.isFavorited? "favorite-button favorited" : "favorite-button"} icon={faHeart} size="3x" onClick={() => {this.determineFavoriteUnfavorite()}}/>
-{!!this.state.message && <p>{this.state.message}</p>} */}

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -111,15 +111,16 @@ class App extends Component {
       <main> 
       <Header />
         <Switch>
-          <Route exact path='/' render={() => {
+          <Route exact path='/' render={({match}) => {
+              const homePath = match.path
               return (
                 <>
                   {this.state.error && <Error error={this.state.error} />}
                   {!this.state.movies.length && !this.state.error && <p>Loading...</p>}
-                  {!this.state.error && <MovieBoard 
+                  {!this.state.error && (<Header path={homePath} />,<MovieBoard 
                     movies={this.state.movies} 
                     selectMovie={this.selectMovie}
-                  />}
+                  />)}
                 </>
               )
             }}
@@ -143,16 +144,18 @@ class App extends Component {
             )
             }}
           />
-          <Route exact path='/favorites' render={() => {
+          <Route exact path='/favorites' render={({match}) => {
+            const favoritePath = match.path
+            console.log(favoritePath)
             return (
               <>
                   {this.state.error && <Error error={this.state.error} />}
                   {!this.state.movies.length && !this.state.error && <p>Loading...</p>}
                   {!this.state.favoriteMovies.length && <p>No Movies!</p>}
-                  {!this.state.error && <MovieBoard 
+                  {!this.state.error && (<Header path={favoritePath} />, <MovieBoard 
                     movies={this.state.favoriteMovies} 
                     selectMovie={this.selectMovie}
-                  />}
+                  />)}
                 </>
             )
             }}

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -143,6 +143,20 @@ class App extends Component {
             )
             }}
           />
+          <Route exact path='/favorites' render={() => {
+            return (
+              <>
+                  {this.state.error && <Error error={this.state.error} />}
+                  {!this.state.movies.length && !this.state.error && <p>Loading...</p>}
+                  {!this.state.favoriteMovies.length && <p>No Movies!</p>}
+                  {!this.state.error && <MovieBoard 
+                    movies={this.state.favoriteMovies} 
+                    selectMovie={this.selectMovie}
+                  />}
+                </>
+            )
+            }}
+          />
           <Route path=''render={() => <Error error='404 Not Found' leaveError={this.leaveError}/>}/>
         </Switch>
       </main>


### PR DESCRIPTION
Add route path to favorite page that is rendered by `this.state.favoriteMovies` when the [server](https://github.com/tylrs/rancid-tomatillos-microservice) is running.

## Motivation and Context
Add another feature to our site using the express server that we made. 

## Concerns

-  Conditional rendering not working because `match.path` is showing as invalid when passed a props to Header

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor

## Checklist:
- Add a route path for favorites page
- Add favorites and back button to the header
- Add logic (partially) for conditionally rendering back/favorite button depending on which page you are on
